### PR TITLE
build ARM image(s)

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -53,3 +53,8 @@ jobs:
         }
       docker_images:
         ghcr.io/product-os/deploynaut
+      docker_runs_on: >
+        {
+          "linux/amd64": ["self-hosted","X64"],
+          "linux/arm64": ["self-hosted","ARM64"]
+        }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,6 @@
+target "default" {
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
there aren't any AMD64 nodes in any of our EKS clusters