### PR TITLE
Enable support for workflow dispatch events

### DIFF
--- a/src/handlers/deployment-protection-rule.ts
+++ b/src/handlers/deployment-protection-rule.ts
@@ -41,7 +41,14 @@ export async function handleDeploymentProtectionRule(
 		return;
 	}
 
-	if (!['pull_request', 'pull_request_target', 'push'].includes(event)) {
+	if (
+		![
+			'pull_request',
+			'pull_request_target',
+			'push',
+			'workflow_dispatch',
+		].includes(event)
+	) {
 		context.log.info(
 			'Ignoring unsupported deployment protection rule event: %s',
 			event,


### PR DESCRIPTION
These events include the same information as pull request events if they are triggered in the context of a PR.

If they are triggered as a standalone workflow run, there will be no associated PRs to find matching reviews and they will remain unapproved.

Change-type: patch