### PR TITLE
Add basejump-app to valid-signatures rule

### DIFF
--- a/.github/deploynaut.yml
+++ b/.github/deploynaut.yml
@@ -29,7 +29,8 @@ approval_rules:
       # the authenticated signatures are attributed to a user in the users list
       # or belong to a user in any of the listed organizations or teams.
       has_valid_signatures_by:
-        users: []
+        users:
+          - "basejump-app"
         organizations: []
         teams:
           - "product-os/security-team"


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Improvement/Add-deployment-rules-for-commits-signed-by-basejump-3053