### PR TITLE
Add deployment ref conditions

### DIFF
--- a/.github/deploynaut.yml
+++ b/.github/deploynaut.yml
@@ -5,6 +5,7 @@ policy:
       - security-team or reliability has approved
       - has valid signatures by security-team or reliability
       - author is renovate-bot or flowzone-app
+      - deployment ref is main or master
 
 # the list of rules
 approval_rules:
@@ -59,5 +60,14 @@ approval_rules:
       environment:
         matches:
           - test
+    requires:
+      count: 0
+
+  # Do not require approvals for deployments from main or master branches
+  - name: deployment ref is main or master
+    if:
+      ref_patterns:
+        - main
+        - master
     requires:
       count: 0

--- a/README.md
+++ b/README.md
@@ -61,12 +61,22 @@ Create a `.github/deploynaut.yml` file in your organization's `.github` reposito
 policy:
   approval:
     - or:
+        - auto-approve-main
         - team-has-approved
         - has-valid-signatures
         - authored-by-bot
 
 # Approval rule definitions
 approval_rules:
+  - name: auto-approve-main
+    if:
+      ref_patterns:
+        - main
+        - master
+        - release/*
+    requires:
+      count: 0
+
   - name: team-has-approved
     requires:
       count: 1
@@ -98,6 +108,7 @@ Each approval rule supports:
 
 #### Conditions (`if`)
 
+- **`ref_patterns`**: Match deployment ref (branch/tag) against regex patterns
 - **`has_valid_signatures_by`**: Commits signed by authorized users/teams/orgs
 - **`only_has_contributors_in`**: Commits authored and committed by authorized users or team members
 - **`environment`**: Environment-specific conditions

--- a/src/handlers/deployment-protection.ts
+++ b/src/handlers/deployment-protection.ts
@@ -48,6 +48,7 @@ export async function handleDeploymentProtectionRuleRequested(
 			name: environment,
 		},
 		deployment: {
+			ref: deployment.ref,
 			environment: environment,
 			event: context.payload.event,
 			commit: {

--- a/src/handlers/pull-request-review.ts
+++ b/src/handlers/pull-request-review.ts
@@ -119,6 +119,7 @@ export async function handlePullRequestReviewSubmitted(
 					const isApproved = await evaluator.evaluate({
 						...approvalContext,
 						deployment: {
+							ref: workflowRun.head_branch,
 							environment: environmentName,
 							event: workflowRun.event,
 							commit: {

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -19,6 +19,7 @@ export interface NamedApprovalRule {
 }
 
 export interface RuleCondition {
+	ref_patterns?: string[];
 	environment?: {
 		matches?: string[];
 		not_matches?: string[];
@@ -87,6 +88,7 @@ export interface PolicyContext {
 		name: string;
 	};
 	deployment?: {
+		ref?: string;
 		environment?: string;
 		event?: string;
 		commit: Commit;

--- a/tests/fixtures/policy-configs/ref-patterns.yml
+++ b/tests/fixtures/policy-configs/ref-patterns.yml
@@ -1,0 +1,22 @@
+# Ref patterns testing with auto-approval for trusted branches
+policy:
+  approval:
+    - or:
+        - auto-approve-main
+        - manual-approval
+
+approval_rules:
+  - name: auto-approve-main
+    if:
+      ref_patterns:
+        - main
+        - master
+    requires:
+      count: 0
+
+  - name: manual-approval
+    requires:
+      count: 1
+      users: ['authorized-reviewer']
+    methods:
+      github_review: true


### PR DESCRIPTION
This condition can be used to match a branch or tag that was used to trigger a deployment, and have a different policy be applied.

A common example would be for deployments from main/master branches do not require approval since the code is already trusted.

Change-type: minor