### PR TITLE
Add conditions `only_has_authors_in` and `has_valid_signatures`

### DIFF
--- a/.github/deploynaut.yml
+++ b/.github/deploynaut.yml
@@ -24,13 +24,14 @@ approval_rules:
 
   - name: has valid signatures by security-team or reliability
     if:
-      # "has_valid_signatures_by" is satisfied if the commits in the pull request
-      # all have git commit signatures that have been verified by GitHub, and
-      # the authenticated signatures are attributed to a user in the users list
-      # or belong to a user in any of the listed organizations or teams.
-      has_valid_signatures_by:
-        users:
-          - "basejump-app"
+      # "has_valid_signatures" is satisfied when all relevant commits
+      # all have git commit signatures that have been verified by GitHub
+      has_valid_signatures: true
+      # "only_has_authors_in" is satisfied when all relevant commits are
+      # authored by users in the users list or that belong to any of the
+      # listed organizations or teams.
+      only_has_authors_in:
+        users: []
         organizations: []
         teams:
           - "product-os/security-team"
@@ -45,9 +46,12 @@ approval_rules:
   # Do not require approvals for renovate or flowzone
   - name: author is renovate-bot or flowzone-app
     if:
-      # "only_has_contributors_in" is satisfied if all of the commits on the
-      # pull request are authored and committed by users in the users list or
-      # that belong to any of the listed organizations or teams.
+      # "has_valid_signatures" is satisfied when all relevant commits
+      # all have git commit signatures that have been verified by GitHub
+      has_valid_signatures: true
+      # "only_has_contributors_in" is satisfied when all relevant commits are
+      # authored and committed by users in the users list or that belong to any
+      # of the listed organizations or teams.
       only_has_contributors_in:
         users:
           - "balena-renovate[bot]"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Each approval rule supports:
 #### Conditions (`if`)
 
 - **`only_has_authors_in`**: Commits authored by authorized users or team members
+- **`has_valid_signatures`**: Commits signed and validated by GitHub
 - **`has_valid_signatures_by`**: Commits signed by authorized users/teams/orgs
 - **`only_has_contributors_in`**: Commits authored and committed by authorized users or team members
 - **`environment`**: Environment-specific conditions

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Each approval rule supports:
 
 #### Conditions (`if`)
 
+- **`only_has_authors_in`**: Commits authored by authorized users or team members
 - **`has_valid_signatures_by`**: Commits signed by authorized users/teams/orgs
 - **`only_has_contributors_in`**: Commits authored and committed by authorized users or team members
 - **`environment`**: Environment-specific conditions

--- a/src/policy/evaluator.ts
+++ b/src/policy/evaluator.ts
@@ -207,44 +207,69 @@ export class PolicyEvaluator {
 	 * @param conditions The conditions to evaluate
 	 * @returns true if all conditions are met, false otherwise
 	 */
-	private async evaluateConditions(
-		conditions: RuleCondition,
-	): Promise<boolean> {
-		// Check environment conditions
-		if (conditions.environment) {
-			const envName = this.context.environment?.name;
-			if (!envName) {
-				this.logger.warn('No environment name found in context');
-				return false;
-			}
-
-			// Check if environment matches allowed list
-			if (
-				conditions.environment.matches &&
-				!conditions.environment.matches.includes(envName)
-			) {
-				this.logger.warn(
-					`Environment "${envName}" does not match any allowed environments`,
-				);
-				return false;
-			}
-
-			// Check if environment is in excluded list
-			if (conditions.environment.not_matches?.includes(envName)) {
-				this.logger.warn(
-					`Environment "${envName}" does not match any allowed environments`,
-				);
-				return false;
-			}
+	private evaluateEnvironmentCondition(
+		condition: NonNullable<RuleCondition['environment']>,
+	): boolean {
+		const envName = this.context.environment?.name;
+		if (!envName) {
+			this.logger.warn('No environment name found in context');
+			return false;
 		}
 
-		if (conditions.has_valid_signatures_by) {
-			const commits = this.context.commits;
-			const { users, organizations, teams } =
-				conditions.has_valid_signatures_by;
+		// Check if environment matches allowed list
+		if (condition.matches && !condition.matches.includes(envName)) {
+			this.logger.warn(
+				`Environment "${envName}" does not match any allowed environments`,
+			);
+			return false;
+		}
 
-			// Check signature verification using GitHub's verification status
-			for (const commit of commits) {
+		// Check if environment is in excluded list
+		if (condition.not_matches?.includes(envName)) {
+			this.logger.warn(
+				`Environment "${envName}" is explicitly excluded by the policy`,
+			);
+			return false;
+		}
+
+		return true;
+	}
+
+	private evaluateHasValidSignaturesCondition(): boolean {
+		const commits = this.context.commits;
+
+		if (commits.length === 0) {
+			this.logger.warn('No commits found for signature validation');
+			return false;
+		}
+		const results = commits.map((commit: Commit) => {
+			// Check if GitHub verified the signature
+			if (!commit.verification?.verified) {
+				this.logger.debug(
+					`Commit "${commit.sha}" signature not verified by GitHub: ${commit.verification?.reason ?? 'unknown'}`,
+				);
+				return false;
+			}
+			this.logger.debug(
+				`Commit "${commit.sha}" signature verified by GitHub: ${commit.verification?.reason ?? 'unknown'}`,
+			);
+			return true;
+		});
+
+		const result = results.every(Boolean);
+		this.logger.info(`Evaluated condition has_valid_signatures: ${result}`);
+		return result;
+	}
+
+	private async evaluateHasValidSignaturesByCondition(
+		condition: NonNullable<RuleCondition['has_valid_signatures_by']>,
+	): Promise<boolean> {
+		const commits = this.context.commits;
+		const { users, organizations, teams } = condition;
+
+		// Check signature verification using GitHub's verification status
+		const results = await Promise.all(
+			commits.map(async (commit: Commit) => {
 				const isValid = await this.validateCommitSignature(commit, {
 					users,
 					organizations,
@@ -254,75 +279,139 @@ export class PolicyEvaluator {
 				if (!isValid) {
 					return false;
 				}
-			}
+				return true;
+			}),
+		);
+
+		const result = results.every(Boolean);
+		this.logger.info(`Evaluated condition has_valid_signatures_by: ${result}`);
+		return result;
+	}
+
+	private async evaluateOnlyHasAuthorsInCondition(
+		condition: NonNullable<RuleCondition['only_has_authors_in']>,
+	): Promise<boolean> {
+		const { users, organizations, teams } = condition;
+		const commits = this.context.commits;
+
+		// If there are no commits, return false
+		if (commits.length === 0) {
+			return false;
+		}
+
+		// Check that all commits were authored by the specified users/organizations/teams
+		const results = await Promise.all(
+			commits.map(async (commit: Commit) => {
+				return await this.isUserInAny(
+					commit.author?.login ?? '',
+					users ?? [],
+					organizations ?? [],
+					teams ?? [],
+				);
+			}),
+		);
+
+		const result = results.every(Boolean);
+		this.logger.info(
+			`Evaluated condition only_has_authors_in: ${JSON.stringify(condition)}: ${result}`,
+		);
+		return result;
+	}
+
+	private async evaluateOnlyHasContributorsInCondition(
+		condition: NonNullable<RuleCondition['only_has_contributors_in']>,
+	): Promise<boolean> {
+		const { users, organizations, teams } = condition;
+		const commits = this.context.commits;
+
+		// If there are no commits, return false
+		if (commits.length === 0) {
+			return false;
+		}
+
+		// Check that all commits were authored and committed by the specified users/organizations/teams
+		const results = await Promise.all(
+			commits.map(async (commit: Commit) => {
+				const author = commit.author;
+				const committer = commit.committer;
+				const isAuthorAuthorized = await this.isUserInAny(
+					author?.login ?? '',
+					users ?? [],
+					organizations ?? [],
+					teams ?? [],
+				);
+				const isCommitterAuthorized = await this.isUserInAny(
+					committer?.login ?? '',
+					users ?? [],
+					organizations ?? [],
+					teams ?? [],
+				);
+				return isAuthorAuthorized && isCommitterAuthorized;
+			}),
+		);
+
+		const result = results.every(Boolean);
+		this.logger.info(
+			`Evaluated condition only_has_contributors_in: ${JSON.stringify(condition)}: ${result}`,
+		);
+		return result;
+	}
+
+	private async evaluateConditions(
+		conditions: RuleCondition,
+	): Promise<boolean> {
+		const conditionPromises: Array<Promise<boolean>> = [];
+
+		// Add condition promises based on what's present in the conditions object
+		if (conditions.environment) {
+			conditionPromises.push(
+				Promise.resolve(
+					this.evaluateEnvironmentCondition(conditions.environment),
+				),
+			);
+		}
+
+		if (conditions.has_valid_signatures) {
+			conditionPromises.push(
+				Promise.resolve(this.evaluateHasValidSignaturesCondition()),
+			);
+		}
+
+		if (conditions.has_valid_signatures_by) {
+			conditionPromises.push(
+				this.evaluateHasValidSignaturesByCondition(
+					conditions.has_valid_signatures_by,
+				),
+			);
 		}
 
 		if (conditions.only_has_authors_in) {
-			const { users, organizations, teams } = conditions.only_has_authors_in;
-			// const commits = await compareCommits(this.githubContext, trustedBranch, this.context.commits[0].sha);
-			const commits = this.context.commits;
-
-			// If there are no commits, return false
-			if (commits.length === 0) {
-				return false;
-			}
-
-			// Check that all commits were authored by the specified users/organizations/teams
-			const results = await Promise.all(
-				commits.map(async (commit: Commit) => {
-					return await this.isUserInAny(
-						commit.author?.login ?? '',
-						users ?? [],
-						organizations ?? [],
-						teams ?? [],
-					);
-				}),
+			conditionPromises.push(
+				this.evaluateOnlyHasAuthorsInCondition(conditions.only_has_authors_in),
 			);
-
-			this.logger.info(
-				`Evaluated condition only_has_authors_in: ${JSON.stringify(conditions.only_has_authors_in)}: ${results.every(Boolean)}`,
-			);
-			return results.every(Boolean);
 		}
 
 		if (conditions.only_has_contributors_in) {
-			const { users, organizations, teams } =
-				conditions.only_has_contributors_in;
-			const commits = this.context.commits;
-
-			// If there are no commits, return false
-			if (commits.length === 0) {
-				return false;
-			}
-
-			// Check that all commits were authored and committed by the specified users/organizations/teams
-			const results = await Promise.all(
-				commits.map(async (commit: Commit) => {
-					const author = commit.author;
-					const committer = commit.committer;
-					const isAuthorAuthorized = await this.isUserInAny(
-						author?.login ?? '',
-						users ?? [],
-						organizations ?? [],
-						teams ?? [],
-					);
-					const isCommitterAuthorized = await this.isUserInAny(
-						committer?.login ?? '',
-						users ?? [],
-						organizations ?? [],
-						teams ?? [],
-					);
-					return isAuthorAuthorized && isCommitterAuthorized;
-				}),
+			conditionPromises.push(
+				this.evaluateOnlyHasContributorsInCondition(
+					conditions.only_has_contributors_in,
+				),
 			);
-
-			this.logger.info(
-				`Evaluated condition only_has_contributors_in: ${JSON.stringify(conditions.only_has_contributors_in)}: ${results.every(Boolean)}`,
-			);
-			return results.every(Boolean);
 		}
 
-		return true;
+		// If no conditions were specified, return true
+		if (conditionPromises.length === 0) {
+			return true;
+		}
+
+		// Wait for all conditions to complete and check if all passed
+		const results = await Promise.all(conditionPromises);
+		const allConditionsPassed = results.every(Boolean);
+
+		this.logger.info(
+			`All conditions evaluation result: ${allConditionsPassed} (${results.length} conditions checked)`,
+		);
+		return allConditionsPassed;
 	}
 
 	private async evaluateRequirements(

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -33,6 +33,11 @@ export interface RuleCondition {
 		organizations?: string[];
 		teams?: string[];
 	};
+	only_has_authors_in?: {
+		users?: string[];
+		organizations?: string[];
+		teams?: string[];
+	};
 }
 
 export interface ApprovalRequirement {

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -23,6 +23,7 @@ export interface RuleCondition {
 		matches?: string[];
 		not_matches?: string[];
 	};
+	has_valid_signatures?: boolean;
 	has_valid_signatures_by?: {
 		users?: string[];
 		organizations?: string[];

--- a/tests/fixtures/policy-configs/has-valid-signatures-by.yml
+++ b/tests/fixtures/policy-configs/has-valid-signatures-by.yml
@@ -7,7 +7,10 @@ policy:
 approval_rules:
   - name: has valid signatures by test-users
     if:
-      # Checks signatures on all the commits in the pull request
+      # "has_valid_signatures_by" is satisfied when all relevant commits
+      # all have git commit signatures that have been verified by GitHub, and
+      # the authenticated signatures are attributed to a user in the users list
+      # or belong to a user in any of the listed organizations or teams.
       has_valid_signatures_by:
         users: []
         organizations: []

--- a/tests/fixtures/policy-configs/has-valid-signatures.yml
+++ b/tests/fixtures/policy-configs/has-valid-signatures.yml
@@ -1,0 +1,14 @@
+# Signature-based approval policy - only requires valid signatures
+policy:
+  approval:
+    - has valid signatures by test-users
+
+# the list of rules
+approval_rules:
+  - name: has valid signatures by test-users
+    if:
+      # "has_valid_signatures" is satisfied when all relevant commits
+      # all have git commit signatures that have been verified by GitHub
+      has_valid_signatures: true
+    requires:
+      count: 0

--- a/tests/fixtures/policy-configs/only-has-authors-in.yml
+++ b/tests/fixtures/policy-configs/only-has-authors-in.yml
@@ -1,0 +1,17 @@
+# Author-based approval policy - only requires specific author
+policy:
+  approval:
+    - was authored by test-bot
+
+# the list of rules
+approval_rules:
+  - name: was authored by test-bot
+    if:
+      # "only_has_authors_in" is satisfied when all relevant commits are
+      # authored by users in the users list or that belong to any of the
+      # listed organizations or teams.
+      only_has_authors_in:
+        users:
+          - test-bot
+    requires:
+      count: 0

--- a/tests/fixtures/policy-configs/only-has-contributors-in.yml
+++ b/tests/fixtures/policy-configs/only-has-contributors-in.yml
@@ -7,9 +7,9 @@ policy:
 approval_rules:
   - name: was authored by test-bot
     if:
-      # "only_has_contributors_in" is satisfied if all of the commits on the
-      # pull request are authored and committed by users in the users list or
-      # that belong to any of the listed organizations or teams.
+      # "only_has_contributors_in" is satisfied when all relevant commits are
+      # authored and committed by users in the users list or that belong to any
+      # of the listed organizations or teams.
       only_has_contributors_in:
         users:
           - test-bot

--- a/tests/policy/evaluator.test.ts
+++ b/tests/policy/evaluator.test.ts
@@ -191,98 +191,6 @@ describe('PolicyEvaluator', () => {
 		expect(await evaluator.evaluate(context)).toBe(false);
 	});
 
-	test('returns true when only_has_contributors_in rule is met', async () => {
-		const config: PolicyConfig = {
-			policy: {
-				approval: ['require_author'],
-			},
-			approval_rules: [
-				{
-					name: 'require_author',
-					if: {
-						only_has_contributors_in: {
-							users: ['test-user'],
-						},
-					},
-				},
-			],
-		};
-
-		const context: PolicyContext = {
-			environment: {
-				name: mockPayload.environment,
-			},
-			deployment: {
-				environment: mockPayload.environment,
-				event: 'push',
-				commit: {
-					sha: mockPayload.deployment.sha,
-				},
-			},
-			reviews: [],
-			commits: [
-				{
-					sha: 'abc123',
-					author: {
-						id: 1,
-						login: 'test-user',
-					},
-					committer: {
-						id: 123,
-						login: 'test-user',
-					},
-				},
-			],
-		};
-
-		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(context)).toBe(true);
-	});
-
-	test('returns false when only_has_contributors_in rule is not met', async () => {
-		const config: PolicyConfig = {
-			policy: {
-				approval: ['require_author'],
-			},
-			approval_rules: [
-				{
-					name: 'require_author',
-					if: {
-						only_has_contributors_in: {
-							users: ['test-user'],
-						},
-					},
-				},
-			],
-		};
-
-		const context: PolicyContext = {
-			environment: {
-				name: mockPayload.environment,
-			},
-			deployment: {
-				environment: mockPayload.environment,
-				event: 'push',
-				commit: {
-					sha: mockPayload.deployment.sha,
-				},
-			},
-			reviews: [],
-			commits: [
-				{
-					sha: 'abc123',
-					author: {
-						id: 1,
-						login: 'different-user',
-					},
-				},
-			],
-		};
-
-		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(context)).toBe(false);
-	});
-
 	test('evaluates simple OR rule', async () => {
 		const config: PolicyConfig = {
 			...baseConfig,
@@ -334,22 +242,32 @@ describe('PolicyEvaluator', () => {
 		expect(await evaluator.evaluate(context)).toBe(true);
 	});
 
-	test('evaluates environment conditions', async () => {
+	test('evaluates simple AND rule', async () => {
 		const config: PolicyConfig = {
 			...baseConfig,
 			policy: {
-				approval: ['env-rule'],
+				approval: [
+					{
+						and: ['test-rule-1', 'test-rule-2'],
+					},
+				],
 			},
 			approval_rules: [
 				{
-					name: 'env-rule',
-					if: {
-						environment: {
-							matches: ['production', 'staging'],
-						},
-					},
+					name: 'test-rule-1',
 					requires: {
 						count: 1,
+						teams: ['test-team'],
+					},
+					methods: {
+						github_review: true,
+					},
+				},
+				{
+					name: 'test-rule-2',
+					requires: {
+						count: 1,
+						users: ['test-reviewer'],
 					},
 					methods: {
 						github_review: true,
@@ -358,8 +276,157 @@ describe('PolicyEvaluator', () => {
 			],
 		};
 
+		const context: PolicyContext = {
+			...baseContext,
+			reviews: [
+				{
+					id: 1,
+					user: {
+						id: 789,
+						login: 'team-member',
+					},
+					state: 'APPROVED',
+					commit_id: 'test-sha',
+					submitted_at: '2021-01-01T00:00:00Z',
+				},
+				{
+					id: 2,
+					user: {
+						id: 678,
+						login: 'test-reviewer',
+					},
+					state: 'APPROVED',
+					commit_id: 'test-sha',
+					submitted_at: '2021-01-01T00:00:00Z',
+				},
+			],
+			commits: [],
+		};
+
 		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(baseContext)).toBe(false); // No approvals yet
+		expect(await evaluator.evaluate(context)).toBe(true);
+	});
+
+	describe('environment condition', () => {
+		test('passes when environment is in matches', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['env-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'env-rule',
+						if: {
+							environment: {
+								matches: ['production', 'staging'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+						methods: {
+							github_review: true,
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(baseContext)).toBe(true);
+		});
+
+		test('passes when environment is not in not_matches', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['env-not-match-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'env-not-match-rule',
+						if: {
+							environment: {
+								not_matches: ['development'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(baseContext)).toBe(true);
+		});
+
+		test('fails when environment is not in matches', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['env-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'env-rule',
+						if: {
+							environment: {
+								matches: ['production', 'staging'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+						methods: {
+							github_review: true,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				environment: {
+					name: 'development',
+				},
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+
+		test('fails when environment is in not_matches', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['env-not-match-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'env-not-match-rule',
+						if: {
+							environment: {
+								not_matches: ['development'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				environment: {
+					name: 'development',
+				},
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
 	});
 
 	test('evaluates signature verification conditions', async () => {
@@ -443,168 +510,6 @@ describe('PolicyEvaluator', () => {
 
 		const evaluator = new PolicyEvaluator(config, mockGithubContext);
 		expect(await evaluator.evaluate(context)).toBe(true);
-	});
-
-	test('evaluates only_has_contributors_in conditions with user requirements', async () => {
-		const config: PolicyConfig = {
-			...baseConfig,
-			policy: {
-				approval: ['author-rule'],
-			},
-			approval_rules: [
-				{
-					name: 'author-rule',
-					if: {
-						only_has_contributors_in: {
-							users: ['test-author'],
-						},
-					},
-					requires: {
-						count: 0,
-					},
-				},
-			],
-		};
-
-		const context: PolicyContext = {
-			...baseContext,
-			reviews: [],
-			commits: [
-				{
-					sha: 'test-sha-1',
-					author: {
-						id: 123,
-						login: 'test-author',
-					},
-					committer: {
-						id: 123,
-						login: 'test-author',
-					},
-				},
-				{
-					sha: 'test-sha-2',
-					author: {
-						id: 123,
-						login: 'test-author',
-					},
-					committer: {
-						id: 123,
-						login: 'test-author',
-					},
-				},
-			],
-		};
-
-		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(context)).toBe(true); // Should pass because all commits are by test-author
-	});
-
-	test('evaluates only_has_contributors_in conditions with team requirements', async () => {
-		const config: PolicyConfig = {
-			...baseConfig,
-			policy: {
-				approval: ['author-team-rule'],
-			},
-			approval_rules: [
-				{
-					name: 'author-team-rule',
-					if: {
-						only_has_contributors_in: {
-							teams: ['test-org/security-team'],
-						},
-					},
-					requires: {
-						count: 0,
-					},
-				},
-			],
-		};
-
-		const context: PolicyContext = {
-			...baseContext,
-			reviews: [],
-			commits: [
-				{
-					sha: 'test-sha-1',
-					author: {
-						id: 123,
-						login: 'test-author',
-					},
-					committer: {
-						id: 123,
-						login: 'test-author',
-					},
-				},
-				{
-					sha: 'test-sha-2',
-					author: {
-						id: 456,
-						login: 'team-member',
-					},
-					committer: {
-						id: 456,
-						login: 'team-member',
-					},
-				},
-			],
-		};
-
-		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(context)).toBe(true); // Should pass because all commits are by security-team members
-	});
-
-	test('evaluates only_has_contributors_in conditions with organization requirements', async () => {
-		const config: PolicyConfig = {
-			...baseConfig,
-			policy: {
-				approval: ['author-org-rule'],
-			},
-			approval_rules: [
-				{
-					name: 'author-org-rule',
-					if: {
-						only_has_contributors_in: {
-							organizations: ['test-org'],
-						},
-					},
-					requires: {
-						count: 0,
-					},
-				},
-			],
-		};
-
-		const context: PolicyContext = {
-			...baseContext,
-			reviews: [],
-			commits: [
-				{
-					sha: 'test-sha-1',
-					author: {
-						id: 123,
-						login: 'test-author',
-					},
-					committer: {
-						id: 123,
-						login: 'test-author',
-					},
-				},
-				{
-					sha: 'test-sha-2',
-					author: {
-						id: 456,
-						login: 'team-member',
-					},
-					committer: {
-						id: 456,
-						login: 'team-member',
-					},
-				},
-			],
-		};
-
-		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(context)).toBe(true); // Should pass because all commits are by test-org members
 	});
 
 	test('evaluates AND conditions with distinct team requirements', async () => {
@@ -701,48 +606,6 @@ describe('PolicyEvaluator', () => {
 		await expect(() => evaluator.evaluate(baseContext)).rejects.toThrow(
 			'Rule "non-existent-rule" not found in configuration',
 		);
-	});
-
-	// Test cases for better coverage
-	test('evaluates environment not_matches condition', async () => {
-		const config: PolicyConfig = {
-			...baseConfig,
-			policy: {
-				approval: ['env-not-match-rule'],
-			},
-			approval_rules: [
-				{
-					name: 'env-not-match-rule',
-					if: {
-						environment: {
-							not_matches: ['development'],
-						},
-					},
-					requires: {
-						count: 0,
-					},
-				},
-			],
-		};
-
-		const context: PolicyContext = {
-			...baseContext,
-			environment: {
-				name: 'production',
-			},
-		};
-
-		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(context)).toBe(true);
-
-		// Test with excluded environment
-		const devContext: PolicyContext = {
-			...baseContext,
-			environment: {
-				name: 'development',
-			},
-		};
-		expect(await evaluator.evaluate(devContext)).toBe(false);
 	});
 
 	test('evaluates has_valid_signatures_by with organization requirements', async () => {
@@ -999,34 +862,605 @@ describe('PolicyEvaluator', () => {
 		);
 	});
 
-	test('handles empty commits for only_has_contributors_in condition', async () => {
-		const config: PolicyConfig = {
-			...baseConfig,
-			policy: {
-				approval: ['author-rule'],
-			},
-			approval_rules: [
-				{
-					name: 'author-rule',
-					if: {
-						only_has_contributors_in: {
-							users: ['test-user'],
+	describe('only_has_contributors_in condition', () => {
+		test('passes when all contributors are in allowed users', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['author-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'author-rule',
+						if: {
+							only_has_contributors_in: {
+								users: ['test-author', 'test-committer'],
+							},
+						},
+						requires: {
+							count: 0,
 						},
 					},
-					requires: {
-						count: 0,
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'test-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
 					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(true);
+		});
+
+		test('passes when all contributors are in allowed teams', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['team-rule'],
 				},
-			],
-		};
+				approval_rules: [
+					{
+						name: 'team-rule',
+						if: {
+							only_has_contributors_in: {
+								teams: ['test-org/security-team'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
 
-		const context: PolicyContext = {
-			...baseContext,
-			commits: [],
-		};
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'test-author',
+						},
+						committer: {
+							id: 456,
+							login: 'team-member',
+						},
+					},
+				],
+			};
 
-		const evaluator = new PolicyEvaluator(config, mockGithubContext);
-		expect(await evaluator.evaluate(context)).toBe(false);
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(true);
+		});
+
+		test('passes when all contributors are in allowed organizations', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['org-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'org-rule',
+						if: {
+							only_has_contributors_in: {
+								organizations: ['test-org'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'test-author',
+						},
+						committer: {
+							id: 456,
+							login: 'org-member',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(true);
+		});
+
+		test('fails when contributor is not in allowed users', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['author-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'author-rule',
+						if: {
+							only_has_contributors_in: {
+								users: ['allowed-user'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'unauthorized-user',
+						},
+						committer: {
+							id: 456,
+							login: 'unauthorized-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+
+		test('fails when contributor is not in allowed teams', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['team-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'team-rule',
+						if: {
+							only_has_contributors_in: {
+								teams: ['test-org/security-team'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'test-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+
+		test('fails when contributor is not in allowed organizations', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['org-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'org-rule',
+						if: {
+							only_has_contributors_in: {
+								organizations: ['test-org'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 999,
+							login: 'external-author',
+						},
+						committer: {
+							id: 888,
+							login: 'external-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+
+		test('fails when there are no commits', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['author-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'author-rule',
+						if: {
+							only_has_contributors_in: {
+								users: ['test-user'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+	});
+
+	describe('only_has_authors_in condition', () => {
+		test('passes when all authors are in allowed users', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['author-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'author-rule',
+						if: {
+							only_has_authors_in: {
+								users: ['test-author', 'second-author'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'test-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+					{
+						sha: 'test-sha-2',
+						author: {
+							id: 789,
+							login: 'second-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(true);
+		});
+
+		test('passes when all authors are in allowed teams', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['team-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'team-rule',
+						if: {
+							only_has_authors_in: {
+								teams: ['test-org/security-team'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'test-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+					{
+						sha: 'test-sha-2',
+						author: {
+							id: 789,
+							login: 'team-member',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(true);
+		});
+
+		test('passes when all authors are in allowed organizations', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['org-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'org-rule',
+						if: {
+							only_has_authors_in: {
+								organizations: ['test-org'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'test-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+					{
+						sha: 'test-sha-2',
+						author: {
+							id: 789,
+							login: 'org-member',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(true);
+		});
+
+		test('fails when author is not in allowed users', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['author-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'author-rule',
+						if: {
+							only_has_authors_in: {
+								users: ['allowed-user'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 123,
+							login: 'unauthorized-user',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+
+		test('fails when author is not in allowed teams', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['team-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'team-rule',
+						if: {
+							only_has_authors_in: {
+								teams: ['test-org/security-team'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 999,
+							login: 'external-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+
+		test('fails when author is not in allowed organizations', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['org-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'org-rule',
+						if: {
+							only_has_authors_in: {
+								organizations: ['test-org'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [
+					{
+						sha: 'test-sha-1',
+						author: {
+							id: 999,
+							login: 'external-author',
+						},
+						committer: {
+							id: 456,
+							login: 'test-committer',
+						},
+					},
+				],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
+
+		test('fails when there are no commits', async () => {
+			const config: PolicyConfig = {
+				...baseConfig,
+				policy: {
+					approval: ['author-rule'],
+				},
+				approval_rules: [
+					{
+						name: 'author-rule',
+						if: {
+							only_has_authors_in: {
+								users: ['test-user'],
+							},
+						},
+						requires: {
+							count: 0,
+						},
+					},
+				],
+			};
+
+			const context: PolicyContext = {
+				...baseContext,
+				commits: [],
+			};
+
+			const evaluator = new PolicyEvaluator(config, mockGithubContext);
+			expect(await evaluator.evaluate(context)).toBe(false);
+		});
 	});
 
 	test('evaluates OR rule structure', async () => {


### PR DESCRIPTION
"only_has_authors_in" is satisfied when all relevant commits are authored by users in the users list or that belong to any of the listed organizations or teams.

This differs from "only_has_contributors_in" in that it does not take into account the committers, and allows filtering on authors only.

"has_valid_signatures" only checks the GitHub verification property of the related commits, and does not require any specific team membership policy.

Change-type: minor